### PR TITLE
Set UseGitVersion versionSpec to 5.6.4

### DIFF
--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -12,7 +12,7 @@ jobs:
   - task: UseGitVersion@5
     displayName: GitVersion
     inputs:
-      versionSpec: 5.x
+      versionSpec: 5.6.4
       useConfigFile: true
       configFilePath: GitVersion.yml
 


### PR DESCRIPTION
Avoids build task error of 'Object reference not set to an instance of an object.'